### PR TITLE
Disable 'push to production' step

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -18,8 +18,3 @@ jobs:
         env:
           INPUT_SCHEMA: /schemas/streams.json
           INPUT_JSONS: /streams.json
-      - name: Push to Production
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.PUSH_TOKEN }}
-          branch: production


### PR DESCRIPTION
Since we do all veting and schema compliance before getting on master it doesn't make sense to have an extra push